### PR TITLE
Rabbit Mutation Category

### DIFF
--- a/doc/JSON_FLAGS.md
+++ b/doc/JSON_FLAGS.md
@@ -1036,7 +1036,6 @@ Also see `monster_attacks.json` for more special attacks, for example, impale an
 - ```BIO_OP_DISARM``` Disarming attack, does no damage.
 - ```BIO_OP_IMPALE``` Stabbing attack, deals heavy damage and has a chance to cause bleeding .
 - ```BITE``` Bite attack that can cause deep infected wounds if the target is `grabbed` at the same time.
-- ```BMG_TUR``` Barrett .50BMG rifle fires.
 - ```BOOMER_GLOW``` Spit glowing bile.
 - ```BOOMER``` Spit bile.
 - ```BRANDISH``` Brandish a knife at the player.
@@ -1111,7 +1110,6 @@ Also see `monster_attacks.json` for more special attacks, for example, impale an
 - ```SHRIEK``` "a terrible shriek!"
 - ```SLIMESPRING``` Can provide a morale boost to the player, and cure bite and bleed effects.
 - ```SMASH``` Smashes the target for massive damage, sending it flying for a number of tiles equal to `("melee_dice" * "melee_dice_sides" * 3) / 10`.
-- ```SMG``` SMG turret fires.
 - ```SPIT_SAP``` Spit sap (acid damage, 12 range).
 - ```STARE``` Stare at the player and inflict ramping debuffs (`taint>tindrift`).
 - ```STRETCH_ATTACK``` Ranged (3 tiles) piercing attack, doing 5-10 damage.


### PR DESCRIPTION
**Summary**

Content "Rabbit Mutation Category"

**Purpose of change**

@squidmoth encouraged me to bring these changes forth to the mainline, as I was working on a few new rabbit mutations and sprites for them as a separate mod. We both agree it's something that is missing and would fit the lore. I am aware of a popular mod that adds it, however it was never made part of the base game. If the authors of those, or the person maintaining wish to use their changes instead, I am more than open to that.
 
**Describe the solution**

In order to keep the mutations in the rabbit category fitting to the species, I have selected traits such as those that affected speed, appearance and size. The PR adds:
Rabbit ears with increased hearing and minor boost to appearance (-1 ugly)
Rabbit tail, as an evolution of the stubby tail. Again -1 ugly
Rabbit feet along with the inability to wear shoes, 10 encumbrance, but also working similarly to hooves, however with a smaller damage amount of 1.5 instead of 3. 
Lagomorph adaptation to cold (name pending,  "bodytemp_modifiers": [ -500, 500 ]) 
Lagomorph mutation to represent the rabbit threshold
And lastly the rabbit nose, so that we may use it as a prerequisite for the existing grazer mutation, along with incisor teeth, as rabbits are not ruminant as cattle, the only required one before.

**Describe alternatives you've considered**

As mentioned before, the changes from previously made mods could take over the ones I made. I also think some numbers might need balance, and I am very open to suggestions.


**Testing**

I have ran a test character through the science challenge start, added the new &existing traits in the rabbit line, with and without using mutagen and serum to ensure both ways worked. Died a few times due to overuse.
Killed a few rabbits to acquire the recipe components for the serum and crafted them.
Put the rabbit feet to the test and it seemed like a reasonable level of damage.

**Additional context**

Test subject before taking excessive amounts of rabbit mutagen: 
![B-2257](https://user-images.githubusercontent.com/15993955/115036702-1fc8a380-9ea4-11eb-8c11-485ad70e5833.png)

After enduring a nearly lethal dose of rabbit mutagen:
![test02](https://user-images.githubusercontent.com/15993955/115037451-db89d300-9ea4-11eb-9776-baaf3fff1ed4.png)

(Please note the graphics for the new traits are still very much in an early stage. And I understand that is a subject for another area.)
